### PR TITLE
[nrf noup] swap_move: skip check when running in s0/s1 context

### DIFF
--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -210,6 +210,18 @@ boot_status_internal_off(const struct boot_status *bs, int elem_sz)
 int
 boot_slots_compatible(struct boot_loader_state *state)
 {
+#ifdef PM_S1_ADDRESS
+    /* Patch needed for NCS. In this case, image 1 primary points to the other
+     * B1 slot (ie S0 or S1), and image 0 primary points to the app.
+     * With this configuration, image 0 and image 1 share the secondary slot.
+     * Hence, the primary slot of image 1 will be *smaller* than image 1's
+     * secondary slot. This is not allowed in upstream mcuboot, so we need
+     * this patch to allow it. Also, all of these checks are redundant when
+     * partition manager is in use, and since we have the same sector size
+     * in all of our flash.
+     */
+        return 1;
+#else
     size_t num_sectors;
     size_t i;
 
@@ -233,6 +245,7 @@ boot_slots_compatible(struct boot_loader_state *state)
     }
 
     return 1;
+#endif /* PM_S1_ADDRESS */
 }
 
 #define BOOT_LOG_SWAP_STATE(area, state)                            \


### PR DESCRIPTION
The nRF boards all have a single flash page size, and
partition manager deals with the size of the
update partitions and so on, so we must skip this check
to avoid getting an error.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>