### PR TITLE
[nrf noup] loader: skip header check for image 1 primary slot

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -147,6 +147,15 @@ boot_read_image_headers(struct boot_loader_state *state, bool require_all,
              *
              * Failure to read any headers is a fatal error.
              */
+#ifdef PM_S1_ADDRESS
+            /* Patch needed for NCS. The primary slot of the second image
+             * (image 1) will not contain a valid image header until an upgrade
+             * of mcuboot has happened (filling S1 with the new version).
+             */
+            if (BOOT_CURR_IMG(state) == 1 && i == 0) {
+                continue;
+            }
+#endif /* PM_S1_ADDRESS */
             if (i > 0 && !require_all) {
                 return 0;
             } else {


### PR DESCRIPTION
In ncs context, image 1 primary slot is the upgrade bank for
mcuboot (IE S0 or S1 depending on the active slot). It is
not required that this slot contains any valid data.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>