### PR TITLE
[nrf noup] Revert of zephyr: arm: Update reading the flash image rese…

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -141,12 +141,8 @@ int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
 
 uint8_t flash_area_get_device_id(const struct flash_area *fa)
 {
-#if defined(CONFIG_ARM)
-    return fa->fa_id;
-#else
-    (void)fa;
-    return FLASH_DEVICE_ID;
-#endif
+	(void)fa;
+	return FLASH_DEVICE_ID;
 }
 
 #define ERASED_VAL 0xff

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -174,26 +174,16 @@ static void do_boot(struct boot_rsp *rsp)
     /* Get ram address for image */
     vt = (struct arm_vector_table *)(rsp->br_hdr->ih_load_addr + rsp->br_hdr->ih_hdr_size);
 #else
+    uintptr_t flash_base;
     int rc;
-    const struct flash_area *fap;
-    static uint32_t dst[2];
 
     /* Jump to flash image */
-    rc = flash_area_open(rsp->br_flash_dev_id, &fap);
+    rc = flash_device_base(rsp->br_flash_dev_id, &flash_base);
     assert(rc == 0);
 
-    rc = flash_area_read(fap, rsp->br_hdr->ih_hdr_size, dst, sizeof(dst));
-    assert(rc == 0);
-#ifndef CONFIG_ASSERT
-    /* Enter a lock up as asserts are disabled */
-    if (rc != 0) {
-        while (1);
-    }
-#endif
-
-    flash_area_close(fap);
-
-    vt = (struct arm_vector_table *)dst;
+    vt = (struct arm_vector_table *)(flash_base +
+                                     rsp->br_image_off +
+                                     rsp->br_hdr->ih_hdr_size);
 #endif
 
     if (IS_ENABLED(CONFIG_SYSTEM_TIMER_HAS_DISABLE_SUPPORT)) {


### PR DESCRIPTION
…t vector

This is revert of upstream commit
 453096b17ddc3aac7bf6afb97c40591d5ea3aa9c
which was supposed to allow picking interrupt vector table from flash area but the whole modification unfortunately misunderstood difference between flash device ID and flash area ID. The commit is not important for sdk-nrf and requires re-design and fixing upstream.