### PR TITLE
[nrf noup] boot: bootutil: Add support for NSIB maximum image size

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -457,6 +457,18 @@ get_first_trailer_sector_end_off(struct boot_loader_state *state, size_t slot, s
 
 uint32_t bootutil_max_image_size(struct boot_loader_state *state, const struct flash_area *fap)
 {
+#if CONFIG_MCUBOOT_MCUBOOT_IMAGE_NUMBER != -1
+    if (BOOT_CURR_IMG(state) == CONFIG_MCUBOOT_MCUBOOT_IMAGE_NUMBER) {
+        /* NSIB is a direct upgrade without any status or trailer, get the full size of the
+         * primary slot.
+         */
+        const struct flash_area *fap_nsib = BOOT_IMG_AREA(state, 0);
+        assert(fap_nsib != NULL);
+
+        return flash_area_get_size(fap_nsib);
+    }
+#endif /* CONFIG_MCUBOOT_MCUBOOT_IMAGE_NUMBER != -1 */
+
 #if defined(MCUBOOT_SINGLE_APPLICATION_SLOT) ||      \
     defined(MCUBOOT_FIRMWARE_LOADER) ||              \
     defined(MCUBOOT_SINGLE_APPLICATION_SLOT_RAM_LOAD)


### PR DESCRIPTION
nrf-squash! [nrf noup] treewide: Add support for sysbuild assigned images

Adds support for getting the maximum allowable image size for NSIB